### PR TITLE
Add the basic behavior for the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Unreleased
 
 ### Added
+
+- The ability to specify authorizers for any HTTP Authorization schemes, whether current or future, through the initializer. These can be anything responding to `#call` with a nilable string argument with a truthy value for success and a falsey one for failure.
+- The ability the set the route for the deploy hook.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,84 @@ Or you can use [an automation script](https://www.bridgetownrb.com/docs/automati
 
 ## Usage
 
+To use a post-deploy hook, you must run Bridgetown with the Roda app; a static website will not work. First, add the Roda plugin to your app and call the helper for enabling the route:
+
+```ruby
+# server/roda_app.rb
+class RodaApp < Bridgetown::Rack::Roda
+  plugin :bridgetown_ssr
+  plugin :bridgetown_deploy_hook
+  
+  route do |r|
+    r.bridgetown_deploy_hook
+  end
+end
+```
+
+Note that you must enable the plugin _after_ the `:bridgetown_ssr` plugin because the latter is what sets up your Bridgetown site for use by the Roda app.
+
+Next, configure your route and authorization methods using the initializer. For example, if you want `/my-deploy-hook` to be the route for your hook and use a static [Bearer token](https://datatracker.ietf.org/doc/html/rfc6750) from your environment variables as an authorization mechanism:
+
+```ruby
+# config/initializers.rb
+
+Bridgetown.configure do
+  init(
+    "bridgetown-deploy_hook",
+    authorization: {
+      bearer: ->(token) { token == ENV["BEARER_TOKEN"] }
+    }
+    route: "my-deploy-hook"
+  )
+end
+```
+
+Lastly, register the action that you want to run with the deploy hook:
+
+```ruby
+# config/initializers.rb
+# ... or any other auto-loaded file in your app
+Bridgetown::Hooks.register_one :site, :post_deploy do |site|
+  # Your code here
+end
+```
+
+`site` is your `Bridgetown::Site` instance so you have access to all of your configuration and resources that you have configured.
+
+### Authorization
+
+You may register anything that responds to `#call`, takes a string argument of the directives for your authorization type, and responds with a truthy value when authorization succeeds.
+
+Each [authorization scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#authentication_schemes) may have a single handler registered to it. Register them with either the symbol or string cooresponding to the lowercase version of the scheme. For example, if you want to register both a [Basic](https://datatracker.ietf.org/doc/html/rfc7617) handler and a [Bearer](https://datatracker.ietf.org/doc/html/rfc6750) handler, that would look like the following:
+
+```ruby
+# config/initializers.rb
+
+Bridgetown.configure do
+  init(
+    "bridgetown-deploy_hook",
+    authorization: {
+      basic: my_basic_handler,
+      bearer: my_bearer_handler,
+    }
+    route: "my-deploy-hook"
+  )
+end
+```
+
+The **handlers receive the raw value from the header**, not a destructured version. So the Basic handler receives the Base64-encoded `user:password` pair, not the user and the password, so you must handle the parsing of the value appropriately for the authorization scheme.
+
+### Plugin authors
+
+Plugins may also interact with the deploy hook by registering their own [non-reloadable](https://www.bridgetownrb.com/docs/plugins/hooks#reloadable-vs-non-reloadable-hooks) hook handlers.
+
+As an example:
+
+```ruby
+Bridgetown::Hooks.register_one :site, :post_deploy, reloadable: false do |site|
+  MyPlugin.do_the_work(site)
+end
+```
 
 ## Contributing
 

--- a/lib/bridgetown-deploy_hook.rb
+++ b/lib/bridgetown-deploy_hook.rb
@@ -7,13 +7,28 @@ require_relative "bridgetown/deploy_hook/version"
 # @see https://www.bridgetownrb.com/
 module Bridgetown
   # A Bridgetown plugin that adds support for post-deploy webhooks
+  #
+  # Post-deploy actions receive the Bridgetown site as a block parameter so can
+  # operate on the site as a whole if they wish. This could be for sending
+  # Webmentions or other linkbacks, notifying your team of a deployment for a
+  # client site, or anything else you might find yourself needing to do.
+  #
+  # @example Adding a post-deploy hook to send a Slack notification
+  #
+  #   Bridgetown::Hooks.register_one :site, :post_deploy do |site|
+  #     SendSlackNotification.call(site)
+  #   end
   module DeployHook
     # The Zeitwerk loader responsible for auto-loading constants
     #
     # @private
     Loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false).tap do |loader|
       loader.ignore(__FILE__)
+      loader.ignore(File.join(__dir__, "bridgetown", "deploy_hook", "initializer"))
+      loader.ignore(File.join(__dir__, "roda", "plugins", "deploy_hook"))
       loader.setup
     end
   end
 end
+
+require_relative "bridgetown/deploy_hook/initializer"

--- a/lib/bridgetown/deploy_hook/authorization.rb
+++ b/lib/bridgetown/deploy_hook/authorization.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Bridgetown
+  module DeployHook
+    # Handles authorizing a request via its [Authorization header][1]
+    #
+    # You can configure the authorization strategies via the
+    # bridgetown-deploy_hook initializer. For example, if you want to allow a
+    # [Bearer token][2], give the configuration a callable at the `:bearer`
+    # value in the authorization parameter.
+    #
+    # @example Allowing a specific Bearer token
+    #
+    #   Bridgetown.configure do
+    #     init(
+    #       "bridgetown-deploy_hook",
+    #       authorization: {
+    #         bearer: ->(token) { token == "myvaluemaybefromtheenvironment" }
+    #       }
+    #     )
+    #   end
+    #
+    # The webhook handler parses the Authorization header and dispatches the
+    # authorization request to the appropriate scheme registered in the
+    # configuration. For example, if you want to allow [HTTP Basic
+    # authorization][3], the scheme is `Basic` so register the `:basic` or
+    # `"basic"` key in the site configuration.
+    #
+    # The authorization parameters are passed directly without any parsing or
+    # conversion so your interpreter will need to be able to convert the raw
+    # string appropriately. Missing values will end up with a `nil` so ensure
+    # you handle the `nil` case as well.
+    #
+    # Handlers can be anything that responds to a `#call` of a String or `nil`
+    # with a Boolean (or any truthy/falsey combination if that floats your
+    # boat).
+    #
+    # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
+    # [2]: https://datatracker.ietf.org/doc/html/rfc6750
+    # [3]: https://datatracker.ietf.org/doc/html/rfc7617
+    class Authorization
+      # The default authorizer that rejects everything
+      #
+      # @private
+      #
+      # @return [#call<String, nil>: Boolean] the authorizer
+      REJECT_ALL = ->(*) { false }.freeze
+
+      # Initializes a new {Authorization}
+      #
+      # @since 0.1.0
+      # @api public
+      #
+      # @example Using the authorizers from the current Bridgetown site
+      #
+      #   Bridgetown::DeployHook::Authorization.new(
+      #     "Basic YmlsYm86dGVzdA==",
+      #     config: Bridgetown::Current.site.config.deploy_hook
+      #   )
+      #
+      # @param header [String, nil] the value from the Authorization header
+      # @param config [HashWithDotAccess::Hash] the deploy hook configuration
+      #   for a `Bridgetown::Site`
+      # @return [void]
+      def initialize(header, config:)
+        scheme, @parameters = header&.split(" ", 2)
+        @authorizer = config.authorization.fetch(scheme&.downcase, REJECT_ALL)
+      end
+
+      # Authorizes the request based on its Authorization header
+      #
+      # @since 0.1.0
+      # @api public
+      #
+      # @example Authorizing every Bearer token (don't do this!)
+      #
+      #   auth = Bridgetown::DeployHook::Authorization.new(
+      #     "Bearer 123",
+      #     config: HashWithDotAccess::Hash.new(
+      #       authorization: {bearer: ->(_) { true }}
+      #     )
+      #   )
+      #   auth.call #=> true
+      #
+      # @return [Boolean] true when authorized, false otherwise
+      def call
+        authorizer.call(parameters)
+      end
+
+      private
+
+      # The authorizer responsible for checking the header value
+      #
+      # This can be anything that responds to a `#call` of a String or `nil`
+      # with a Boolean.
+      #
+      # @api private
+      # @private
+      #
+      # @return [#call<String, nil>: Boolean]
+      attr_reader :authorizer
+
+      # The parameters extracted from the Authorization header
+      #
+      # @api private
+      # @private
+      #
+      # @return [String, nil]
+      attr_reader :parameters
+    end
+  end
+end

--- a/lib/bridgetown/deploy_hook/initializer.rb
+++ b/lib/bridgetown/deploy_hook/initializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# @param config [HashWithDotAccess::Hash] the configuration for the Bridgetown site
+# @param authorization [Hash<(Symbol, String, nil), #call<String, nil>: Boolean>] a
+#   Hash mapping Authorization schemes to authenticators, callables that map
+#   string-encoded parameters to Boolean values to indicate whether the attempt
+#   was a success or failure
+# @param route [String] the route for the deploy hook within the Roda application
+Bridgetown.initializer "bridgetown-deploy_hook" do |config, authorization: {}, route: "_bridgetown/deploy"|
+  options = {authorization: authorization, route: route}
+
+  # :nocov: Because it's not possible to show coverage for both branches
+  if config.deploy_hook
+    config.deploy_hook Bridgetown::Utils.deep_merge_hashes(options, config.deploy_hook)
+  else
+    config.deploy_hook(options)
+  end
+  # :nocov:
+end

--- a/lib/bridgetown/deploy_hook/version.rb
+++ b/lib/bridgetown/deploy_hook/version.rb
@@ -2,6 +2,9 @@
 
 module Bridgetown
   module DeployHook
+    # The current version of the gem
+    #
+    # @private
     VERSION = "0.1.0"
   end
 end

--- a/lib/roda/plugins/bridgetown_deploy_hook.rb
+++ b/lib/roda/plugins/bridgetown_deploy_hook.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# A routing tree for building Rack applications
+#
+# @see https://roda.jeremyevans.net/
+class Roda
+  # The namespace Roda uses for loading plugins by convention
+  module RodaPlugins
+    # A plugin that integrates a post-deploy webhook into a Bridgetown Roda app
+    #
+    # This plugin requires the Bridgetown SSR plugin to be enabled before it.
+    #
+    # It creates a route via the configuration set in the initializer that
+    # authorizes requests via {Bridgetown::DeployHook::Authorization} and runs
+    # the post deploy hook when authorized.
+    #
+    # See {Bridgetown::DeployHook} for an example of adding a post-deploy hook.
+    #
+    # See {Bridgetown::DeployHook::Authorization} for more information about
+    # authorization strategies.
+    module BridgetownDeployHook
+      # The string representing an empty response body
+      #
+      # @api private
+      # @private
+      EMPTY_BODY = ""
+
+      # The Roda hook for configuring the plugin
+      #
+      # @since 0.1.0
+      # @api public
+      #
+      # @example Adding the plugin to your Bridgetown Roda app
+      #
+      #    class RodaApp < Bridgetown::Rack::Roda
+      #      plugin :bridgetown_ssr
+      #      plugin :bridgetown_deploy_hook
+      #    end
+      #
+      # @param app [::Roda] the Roda application to configure
+      # @return [void]
+      def self.configure(app)
+        return unless app.opts[:bridgetown_site].nil?
+
+        # :nocov: Because it's difficult to set up multiple contexts
+        raise(
+          "Roda app failure: the bridgetown_ssr plugin must be registered before " \
+          "bridgetown_deploy_hook"
+        )
+        # :nocov:
+      end
+
+      # Methods included in to the Roda request
+      #
+      # @see http://roda.jeremyevans.net/rdoc/classes/Roda/RodaPlugins/Base/RequestMethods.html
+      module RequestMethods
+        # Builds the deploy hook route within the Roda application
+        #
+        # @since 0.1.0
+        # @api public
+        #
+        # @example Enabling the deploy hook route
+        #
+        #   class RodaApp < Bridgetown::Rack::Roda
+        #     plugin :bridgetown_ssr
+        #     plugin :bridgetown_deploy_hook
+        #
+        #     route do |r|
+        #       r.bridgetown_deploy_hook
+        #     end
+        #   end
+        #
+        # @return [void]
+        def bridgetown_deploy_hook
+          site = roda_class.opts[:bridgetown_site]
+          config = site.config.deploy_hook
+
+          on(config.route) do
+            is do
+              authorization = Bridgetown::DeployHook::Authorization.new(
+                env["HTTP_AUTHORIZATION"],
+                config: config
+              )
+
+              response["Content-Type"] = "application/json"
+
+              if (authorized = authorization.call)
+                response.status = 200
+                response.write('{"status":"success"}')
+              else
+                response["WWW-Authenticate"] = config.authorization.keys
+                response.status = 401
+
+                response.write('{"status":"error","error":"unauthorized"}')
+              end
+
+              get do
+                Bridgetown::Hooks.trigger(:site, :post_deploy, site) if authorized
+
+                halt response.finish
+              end
+
+              head do
+                response.finish # to properly set the Content-Length header
+                halt response.finish_with_body(EMPTY_BODY)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    register_plugin :bridgetown_deploy_hook, BridgetownDeployHook
+  end
+end

--- a/test/bridgetown/deploy_hook/test_initializer.rb
+++ b/test/bridgetown/deploy_hook/test_initializer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Bridgetown
+  module DeployHook
+    class TestInitializer < Bridgetown::TestCase
+      def setup
+        super
+        @config = Bridgetown.configuration(
+          "root_dir" => root_dir,
+          "source" => source_dir,
+          "destination" => dest_dir,
+          "quiet" => true
+        )
+        @site = Bridgetown::Site.new(@config)
+        maybe_reload_initializer(@config)
+      end
+
+      def test_merging_into_preexisting_configuration_prefers_the_preexisting
+        with_initializer(<<~RUBY)
+          Bridgetown.configure do
+            deploy_hook do
+              authorization do
+                basic ->(_) { true }
+                bearer ->(_) { true }
+              end
+              route "preexisting"
+            end
+
+            init "bridgetown-deploy_hook", authorization: {basic: "ignored"}, route: "ignored"
+          end
+        RUBY
+
+        @config.run_initializers! context: :static
+
+        assert_equal "preexisting", @config.deploy_hook.route
+        assert_equal ["basic", "bearer"], @config.deploy_hook.authorization.keys
+        assert(
+          @config.deploy_hook.authorization.basic.respond_to?(:call),
+          "The basic configuration was not ignored"
+        )
+      end
+    end
+  end
+end

--- a/test/integration/config/initializers.rb
+++ b/test/integration/config/initializers.rb
@@ -5,5 +5,15 @@ require "bridgetown-deploy_hook"
 Bridgetown.configure do |config|
   url "https://bagend.com"
 
-  init "bridgetown-deploy_hook"
+  init(
+    "bridgetown-deploy_hook",
+    authorization: {
+      bearer: ->(token) { token == "Ilikelessthanhalfofyouhalfaswellasyoudeserve" }
+    },
+    route: "_deploy"
+  )
+end
+
+Bridgetown::Hooks.register_one :site, :post_deploy do |site|
+  site.config.post_deploy_ran_at Time.now
 end

--- a/test/integration/server/roda_app.rb
+++ b/test/integration/server/roda_app.rb
@@ -10,7 +10,9 @@ class RodaApp < Bridgetown::Rack::Roda
     end
   )
   plugin :bridgetown_ssr
+  plugin :bridgetown_deploy_hook
 
   route do |r|
+    r.bridgetown_deploy_hook
   end
 end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -11,6 +11,67 @@ module Bridgetown
     class TestIntegration < Bridgetown::TestCase
       include Rack::Test::Methods
 
+      def setup
+        super
+        site.config.delete(:post_deploy_ran_at)
+      end
+
+      def test_authorized_requests
+        webhook "Bearer Ilikelessthanhalfofyouhalfaswellasyoudeserve"
+
+        assert last_response.ok?, "Response was #{last_response.status}, not 200 OK"
+        assert_equal "success", last_response.body.then { |b| JSON.parse(b) }["status"]
+      end
+
+      def test_authorized_head_requests
+        head_check "Bearer Ilikelessthanhalfofyouhalfaswellasyoudeserve"
+
+        assert last_response.ok?, "Response was #{last_response.status}, not 200 OK"
+        assert_empty last_response.body
+      end
+
+      def test_malformed_authorization_header
+        webhook ""
+
+        assert last_response.unauthorized?, "Response was #{last_response.status}, not 403 Unauthorized"
+        assert_equal "unauthorized", last_response.body.then { |b| JSON.parse(b) }["error"]
+      end
+
+      def test_unauthorized_requests
+        webhook "Bearer IdontknowhalfofyouhalfaswellasIshouldlike"
+
+        assert last_response.unauthorized?, "Response was #{last_response.status}, not 403 Unauthorized"
+        assert_equal "unauthorized", last_response.body.then { |b| JSON.parse(b) }["error"]
+      end
+
+      def test_authorization_by_unknown_credential_type
+        webhook "Basic YmlsYm86dGVzdA=="
+
+        assert last_response.unauthorized?, "Response was #{last_response.status}, not 403 Unauthorized"
+        assert_equal "unauthorized", last_response.body.then { |b| JSON.parse(b) }["error"]
+      end
+
+      def test_unauthorized_head_requests
+        head_check
+
+        assert last_response.unauthorized?, "Response was #{last_response.status}, not 403 Unauthorized"
+        assert_empty last_response.body
+      end
+
+      private
+
+      def head_check(auth = nil)
+        head "/_deploy", {}, {"HTTP_AUTHORIZATION" => auth}.compact
+      end
+
+      def options_check(auth = nil)
+        options "/_deploy", {}, {"HTTP_AUTHORIZATION" => auth}.compact
+      end
+
+      def webhook(auth)
+        get "/_deploy", {}, {"HTTP_AUTHORIZATION" => auth}
+      end
+
       def app
         ENV["RACK_ENV"] = "development"
         @@deploy_hook_app ||= ::Rack::Builder.parse_file(


### PR DESCRIPTION
This change includes the ability to configure the plugin's authorization and route, the Roda plugin, and the initializer definition along with the tests for the behavior.

Readme-driven development at its finest.