### PR TITLE
Don't duplicate runs on push to the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
Ideally, we would test any branch pushed to the repository, but the original configuration duplicated runs for every PR sent from the repository.

This change only tests the main branch on push and pull requests against any branch. This will suffice for now.